### PR TITLE
chore: upgrade poi-ooxml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>4.1.1</version>
+            <version>5.2.5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- bump org.apache.poi:poi-ooxml to 5.2.5

## Testing
- `./mvnw dependency:tree` *(fails: Proxy tunneling failed: ForbiddenUnable to establish SSL connection)*
- `mvn dependency:tree` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b02d4e8b08320b65aa2ac4a5b9af1