### PR TITLE
chore: use mysql-connector-j 8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
 
         <dependency>
             <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.2.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://localhost:3306/smart_plan?userSSL=false
 spring.datasource.username=root
 spring.datasource.password=root
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL5InnoDBDialect
 


### PR DESCRIPTION
## Summary
- replace deprecated `mysql:mysql-connector-java` with `mysql:mysql-connector-j`
- pin MySQL connector to version 8.2.0

## Testing
- `bash mvnw dependency:tree -Dincludes=mysql:mysql-connector-j` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*
- `mvn dependency:tree -Dincludes=mysql:mysql-connector-j` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.3.3.RELEASE: Network is unreachable)*
- `bash mvnw test` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.3.3.RELEASE: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b02d598788320a61ffa7ee51ffe6e