### PR TITLE
chore: upgrade commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.15.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- upgrade commons-io to 2.15.0

## Testing
- `mvn dependency:tree` *(fails: Network is unreachable)*
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b02d32e5083208c72ff9f9e735d85