### PR TITLE
Migrate to Spring Boot 3 and Jakarta APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <version>3.2.5</version>
         <relativePath/>
     </parent>
     <groupId>net.smartPlan</groupId>
@@ -28,7 +28,7 @@
 
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/net/smartplan/fitness/entity/AdminDetails.java
+++ b/src/main/java/net/smartplan/fitness/entity/AdminDetails.java
@@ -7,8 +7,8 @@ import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 
 /**

--- a/src/main/java/net/smartplan/fitness/entity/CaloriePlan.java
+++ b/src/main/java/net/smartplan/fitness/entity/CaloriePlan.java
@@ -4,8 +4,8 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/src/main/java/net/smartplan/fitness/entity/Cart.java
+++ b/src/main/java/net/smartplan/fitness/entity/Cart.java
@@ -3,8 +3,8 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
 
 /**

--- a/src/main/java/net/smartplan/fitness/entity/ChatMessages.java
+++ b/src/main/java/net/smartplan/fitness/entity/ChatMessages.java
@@ -3,8 +3,8 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;

--- a/src/main/java/net/smartplan/fitness/entity/ChatRoom.java
+++ b/src/main/java/net/smartplan/fitness/entity/ChatRoom.java
@@ -3,9 +3,9 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;

--- a/src/main/java/net/smartplan/fitness/entity/FileMetadata.java
+++ b/src/main/java/net/smartplan/fitness/entity/FileMetadata.java
@@ -3,8 +3,8 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/src/main/java/net/smartplan/fitness/entity/FileStorage.java
+++ b/src/main/java/net/smartplan/fitness/entity/FileStorage.java
@@ -3,8 +3,8 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;

--- a/src/main/java/net/smartplan/fitness/entity/GeneralSystemSettings.java
+++ b/src/main/java/net/smartplan/fitness/entity/GeneralSystemSettings.java
@@ -4,8 +4,8 @@ import lombok.*;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 import java.util.Objects;
 

--- a/src/main/java/net/smartplan/fitness/entity/IdentifyTrace.java
+++ b/src/main/java/net/smartplan/fitness/entity/IdentifyTrace.java
@@ -5,8 +5,8 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 import java.util.Objects;
 

--- a/src/main/java/net/smartplan/fitness/entity/MacronutrientFood.java
+++ b/src/main/java/net/smartplan/fitness/entity/MacronutrientFood.java
@@ -4,8 +4,8 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/src/main/java/net/smartplan/fitness/entity/Meal.java
+++ b/src/main/java/net/smartplan/fitness/entity/Meal.java
@@ -6,8 +6,8 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;

--- a/src/main/java/net/smartplan/fitness/entity/MealIngredients.java
+++ b/src/main/java/net/smartplan/fitness/entity/MealIngredients.java
@@ -4,8 +4,8 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/src/main/java/net/smartplan/fitness/entity/Purchase.java
+++ b/src/main/java/net/smartplan/fitness/entity/Purchase.java
@@ -6,8 +6,8 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;

--- a/src/main/java/net/smartplan/fitness/entity/PurchaseDetails.java
+++ b/src/main/java/net/smartplan/fitness/entity/PurchaseDetails.java
@@ -4,8 +4,8 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/src/main/java/net/smartplan/fitness/entity/UnitType.java
+++ b/src/main/java/net/smartplan/fitness/entity/UnitType.java
@@ -5,8 +5,8 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 import java.util.Objects;
 

--- a/src/main/java/net/smartplan/fitness/entity/User.java
+++ b/src/main/java/net/smartplan/fitness/entity/User.java
@@ -6,8 +6,8 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/net/smartplan/fitness/entity/UserAddress.java
+++ b/src/main/java/net/smartplan/fitness/entity/UserAddress.java
@@ -4,8 +4,8 @@ package net.smartplan.fitness.entity;
 import lombok.*;
 import org.hibernate.Hibernate;
 
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;

--- a/src/main/java/net/smartplan/fitness/service/impl/EmailServiceImpl.java
+++ b/src/main/java/net/smartplan/fitness/service/impl/EmailServiceImpl.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import java.util.Date;
 import java.util.List;
 

--- a/src/main/java/net/smartplan/fitness/service/impl/FileServiceImpl.java
+++ b/src/main/java/net/smartplan/fitness/service/impl/FileServiceImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/src/main/java/net/smartplan/fitness/service/impl/MealServiceImpl.java
+++ b/src/main/java/net/smartplan/fitness/service/impl/MealServiceImpl.java
@@ -21,7 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/main/java/net/smartplan/fitness/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/net/smartplan/fitness/service/impl/PurchaseServiceImpl.java
@@ -15,7 +15,7 @@ import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/main/java/net/smartplan/fitness/service/impl/SystemSettingsServiceImpl.java
+++ b/src/main/java/net/smartplan/fitness/service/impl/SystemSettingsServiceImpl.java
@@ -8,7 +8,7 @@ import net.smartplan.fitness.service.SystemSettingsService;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/net/smartplan/fitness/service/impl/UserServiceImpl.java
+++ b/src/main/java/net/smartplan/fitness/service/impl/UserServiceImpl.java
@@ -15,7 +15,7 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESedeKeySpec;
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;


### PR DESCRIPTION
## Summary
- Upgrade project to Spring Boot parent 3.2.5 and Java 17 baseline.
- Replace legacy javax persistence and transaction imports with jakarta equivalents throughout the codebase.
- Update XML binding imports to Jakarta packages for compatibility.

## Testing
- `mvn clean test` *(fails: Non-resolvable parent POM for net.smartPlan: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b02c851bc8320b30c8d8e48b13ec8