### PR TITLE
Upgrade to Spring Boot 3 and Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <version>3.2.5</version>
         <relativePath/>
     </parent>
     <groupId>net.smartPlan</groupId>
@@ -28,7 +28,7 @@
 
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <dependencies>
@@ -42,8 +42,8 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- upgrade to Spring Boot 3.2.5 parent
- set Java version to 21
- use `mysql-connector-j` driver managed by Spring Boot BOM

## Testing
- `mvn clean test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b02b380dc83209aa9257b9a0aa4ea