### PR TITLE
build: bump modelmapper to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
-            <version>2.3.0</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- update ModelMapper dependency to the latest 3.x release

## Testing
- `mvn -q dependency:tree -Dincludes=org.modelmapper:modelmapper` *(fails: Network is unreachable)*
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b02ca15688320b09d7711b1f8b275