### PR TITLE
Handle missing file in FileController

### DIFF
--- a/src/main/java/net/smartplan/fitness/controller/FileController.java
+++ b/src/main/java/net/smartplan/fitness/controller/FileController.java
@@ -45,8 +45,9 @@ public class FileController {
         FileStorage fileDetails = fileStorageRepository.findByFileId(fileId);
         if (fileDetails == null) {
             log.info("Requested resource is not found! {}", fileId);
-            return null;
+            return ResponseEntity.notFound().build();
         }
+
         Resource resource = fileService.loadFileAsResource(fileDetails.getAbsolutePath());
 
         if (resource == null) {


### PR DESCRIPTION
## Summary
- Return a 404 response instead of null when requested file metadata does not exist

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM...)*

------
https://chatgpt.com/codex/tasks/task_e_689b0d31bf408320badfe59bad6d64ed